### PR TITLE
[zone_texts] Add hack to extract gm home and pirate ships

### DIFF
--- a/zone_texts.py
+++ b/zone_texts.py
@@ -145,7 +145,15 @@ def zone_texts():
     for area in areas_xml['thing-list']['thing']:
         try:
             index = int(area['field'][0]['#text'])
-            name = area['field'][1]['#text']
+
+            if index == 227:
+                name = "Ship bound for Selbina Pirates"
+            elif index == 228:
+                name = "Ship bound for Mhaura Pirates"
+            elif index == 210:
+                name = "GM home"
+            else:
+                name = area['field'][1]['#text']
             name = sanitize_zone_name(name)
 
             # Make folders


### PR DESCRIPTION
Does what it says on the tin, tested and verified it works.

Previously gm home had no name in the DATs, and the 2 pirate ships look "duplicate" when they really aren't.