### PR TITLE
Remove [P1], [P2] from sanitize_zone_name

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -54,8 +54,6 @@ def sanitize_zone_name(name):
     name = name.replace("[U]", "U")
     name = name.replace("-LegionA", "-Legion_A")
     name = name.replace("-LegionB", "-Legion_B")
-    name = name.replace("[P1]", "P1")
-    name = name.replace("[P2]", "P2")
     name = name.replace("Escha-", "Escha_")
     name = name.replace("Desuetia-Empyreal", "Desuetia_Empyreal")
     return name


### PR DESCRIPTION
Walk of Echoes P1 and P2 currently use the [PX] format in directory structure.  Removes those two replacements for successful updates for all ID scripts